### PR TITLE
Add burger menu with home and more pages

### DIFF
--- a/HomeMAUI/App.xaml.cs
+++ b/HomeMAUI/App.xaml.cs
@@ -1,4 +1,7 @@
-﻿namespace HomeMAUI;
+﻿using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace HomeMAUI;
 
 public partial class App : Application
 {

--- a/HomeMAUI/AppShell.xaml
+++ b/HomeMAUI/AppShell.xaml
@@ -4,7 +4,14 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:HomeMAUI"
-    Title="HomeMAUI">
+    Title="HomeMAUI"
+    FlyoutBehavior="Disabled">
+
+    <ToolbarItem
+        IconImageSource="menu.svg"
+        Order="Primary"
+        Priority="0"
+        Clicked="OnMenuClicked" />
 
     <ShellContent
         Title="Home"

--- a/HomeMAUI/AppShell.xaml.cs
+++ b/HomeMAUI/AppShell.xaml.cs
@@ -1,3 +1,6 @@
+using System;
+using Microsoft.Maui.Controls;
+
 namespace HomeMAUI;
 
 public partial class AppShell : Shell

--- a/HomeMAUI/AppShell.xaml.cs
+++ b/HomeMAUI/AppShell.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Controls;
+
 namespace HomeMAUI;
 
 public partial class AppShell : Shell

--- a/HomeMAUI/AppShell.xaml.cs
+++ b/HomeMAUI/AppShell.xaml.cs
@@ -1,9 +1,23 @@
-﻿namespace HomeMAUI;
+namespace HomeMAUI;
 
 public partial class AppShell : Shell
 {
-	public AppShell()
-	{
-		InitializeComponent();
-	}
+    public AppShell()
+    {
+        InitializeComponent();
+        Routing.RegisterRoute(nameof(MorePage), typeof(MorePage));
+    }
+
+    private async void OnMenuClicked(object? sender, EventArgs e)
+    {
+        string? action = await DisplayActionSheet("Menu", "Cancel", null, "Home", "More");
+        if (action == "Home")
+        {
+            await GoToAsync("//MainPage");
+        }
+        else if (action == "More")
+        {
+            await GoToAsync(nameof(MorePage));
+        }
+    }
 }

--- a/HomeMAUI/GlobalXmlns.cs
+++ b/HomeMAUI/GlobalXmlns.cs
@@ -1,2 +1,4 @@
+using Microsoft.Maui.Controls;
+
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/maui/global", "HomeMAUI")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/maui/global", "HomeMAUI.Pages")]

--- a/HomeMAUI/HomeMAUI.csproj
+++ b/HomeMAUI/HomeMAUI.csproj
@@ -7,7 +7,6 @@
 		<RootNamespace>HomeMAUI</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
 		<!-- Display name -->

--- a/HomeMAUI/MainPage.xaml.cs
+++ b/HomeMAUI/MainPage.xaml.cs
@@ -1,4 +1,8 @@
-﻿namespace HomeMAUI;
+﻿using System;
+using Microsoft.Maui.Accessibility;
+using Microsoft.Maui.Controls;
+
+namespace HomeMAUI;
 
 public partial class MainPage : ContentPage
 {

--- a/HomeMAUI/MauiProgram.cs
+++ b/HomeMAUI/MauiProgram.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
 
 namespace HomeMAUI;
 

--- a/HomeMAUI/MorePage.xaml
+++ b/HomeMAUI/MorePage.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HomeMAUI.MorePage"
+             Title="More">
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,0"
+            Spacing="25">
+            <Label
+                Text="More Page"
+                Style="{StaticResource Headline}"
+                SemanticProperties.HeadingLevel="Level1" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/HomeMAUI/MorePage.xaml.cs
+++ b/HomeMAUI/MorePage.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Controls;
+
 namespace HomeMAUI;
 
 public partial class MorePage : ContentPage

--- a/HomeMAUI/MorePage.xaml.cs
+++ b/HomeMAUI/MorePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace HomeMAUI;
+
+public partial class MorePage : ContentPage
+{
+    public MorePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/HomeMAUI/Platforms/Android/MainActivity.cs
+++ b/HomeMAUI/Platforms/Android/MainActivity.cs
@@ -1,6 +1,7 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Microsoft.Maui;
 
 namespace HomeMAUI;
 

--- a/HomeMAUI/Platforms/Android/MainApplication.cs
+++ b/HomeMAUI/Platforms/Android/MainApplication.cs
@@ -1,5 +1,8 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Runtime;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
 
 namespace HomeMAUI;
 

--- a/HomeMAUI/Platforms/iOS/AppDelegate.cs
+++ b/HomeMAUI/Platforms/iOS/AppDelegate.cs
@@ -1,4 +1,6 @@
 ﻿using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
 
 namespace HomeMAUI;
 

--- a/HomeMAUI/Resources/Images/menu.svg
+++ b/HomeMAUI/Resources/Images/menu.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect y="4" width="24" height="2" fill="black" />
+  <rect y="11" width="24" height="2" fill="black" />
+  <rect y="18" width="24" height="2" fill="black" />
+</svg>


### PR DESCRIPTION
## Summary
- add hamburger toolbar menu on the right side of the navigation bar
- implement action sheet navigation between Home and new More page
- include simple SVG icon and More page content

## Testing
- `dotnet build HomeMAUI/HomeMAUI.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3710a5883209cd32992fa2277b3