### PR TITLE
Use standard Shell flyout menu

### DIFF
--- a/HomeMAUI/AppShell.xaml
+++ b/HomeMAUI/AppShell.xaml
@@ -6,9 +6,16 @@
     xmlns:local="clr-namespace:HomeMAUI"
     Title="HomeMAUI">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
+    <FlyoutItem Title="Home">
+        <ShellContent
+            ContentTemplate="{DataTemplate local:MainPage}"
+            Route="MainPage" />
+    </FlyoutItem>
+
+    <FlyoutItem Title="More">
+        <ShellContent
+            ContentTemplate="{DataTemplate local:MorePage}"
+            Route="MorePage" />
+    </FlyoutItem>
 
 </Shell>

--- a/HomeMAUI/MorePage.xaml
+++ b/HomeMAUI/MorePage.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HomeMAUI.MorePage"
+             Title="More">
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,0"
+            Spacing="25">
+            <Label
+                Text="More Page"
+                Style="{StaticResource Headline}"
+                SemanticProperties.HeadingLevel="Level1" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/HomeMAUI/MorePage.xaml.cs
+++ b/HomeMAUI/MorePage.xaml.cs
@@ -1,8 +1,8 @@
 namespace HomeMAUI;
 
-public partial class AppShell : Shell
+public partial class MorePage : ContentPage
 {
-    public AppShell()
+    public MorePage()
     {
         InitializeComponent();
     }

--- a/HomeMAUI/Resources/Images/menu.svg
+++ b/HomeMAUI/Resources/Images/menu.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect y="4" width="24" height="2" fill="black" />
+  <rect y="11" width="24" height="2" fill="black" />
+  <rect y="18" width="24" height="2" fill="black" />
+</svg>


### PR DESCRIPTION
## Summary
- Replace custom toolbar-based menu with MAUI Shell flyout containing Home and More pages
- Simplify `AppShell` code by removing action sheet handler

## Testing
- `dotnet build HomeMAUI/HomeMAUI.csproj` *(fails: target platform android not recognized with .NET 8 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3710a5883209cd32992fa2277b3