### PR TITLE
Add device navigation flow with connect and dashboard pages

### DIFF
--- a/HomeMAUI/AppShell.xaml.cs
+++ b/HomeMAUI/AppShell.xaml.cs
@@ -1,9 +1,11 @@
-﻿namespace HomeMAUI;
+namespace HomeMAUI;
 
 public partial class AppShell : Shell
 {
-	public AppShell()
-	{
-		InitializeComponent();
-	}
+    public AppShell()
+    {
+        InitializeComponent();
+        Routing.RegisterRoute(nameof(ConnectPage), typeof(ConnectPage));
+        Routing.RegisterRoute(nameof(DeviceDashboardPage), typeof(DeviceDashboardPage));
+    }
 }

--- a/HomeMAUI/ConnectPage.xaml
+++ b/HomeMAUI/ConnectPage.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HomeMAUI.ConnectPage">
+    <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
+        <Label Text="{Binding Name}" FontSize="24"/>
+    </StackLayout>
+</ContentPage>

--- a/HomeMAUI/ConnectPage.xaml.cs
+++ b/HomeMAUI/ConnectPage.xaml.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HomeMAUI.Models;
+
+namespace HomeMAUI;
+
+[QueryProperty(nameof(Device), "device")]
+public partial class ConnectPage : ContentPage
+{
+    public ConnectPage()
+    {
+        InitializeComponent();
+    }
+
+    public Device? Device
+    {
+        get => BindingContext as Device;
+        set => BindingContext = value;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await Task.Delay(2000);
+        await Shell.Current.GoToAsync(nameof(DeviceDashboardPage), new Dictionary<string, object>
+        {
+            { "device", Device! }
+        });
+        Shell.Current.Navigation.RemovePage(this);
+    }
+}

--- a/HomeMAUI/DeviceDashboardPage.xaml
+++ b/HomeMAUI/DeviceDashboardPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HomeMAUI.DeviceDashboardPage">
+    <StackLayout Padding="20" Spacing="10">
+        <Label Text="{Binding Name}" FontSize="24" FontAttributes="Bold"/>
+        <Label Text="{Binding Rssi, StringFormat='RSSI: {0}'}" />
+        <Label Text="{Binding BleAddress, StringFormat='BLE: {0}'}" />
+    </StackLayout>
+</ContentPage>

--- a/HomeMAUI/DeviceDashboardPage.xaml.cs
+++ b/HomeMAUI/DeviceDashboardPage.xaml.cs
@@ -1,0 +1,18 @@
+using HomeMAUI.Models;
+
+namespace HomeMAUI;
+
+[QueryProperty(nameof(Device), "device")]
+public partial class DeviceDashboardPage : ContentPage
+{
+    public DeviceDashboardPage()
+    {
+        InitializeComponent();
+    }
+
+    public Device? Device
+    {
+        get => BindingContext as Device;
+        set => BindingContext = value;
+    }
+}

--- a/HomeMAUI/MainPage.xaml
+++ b/HomeMAUI/MainPage.xaml
@@ -1,36 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:HomeMAUI.Models"
              x:Class="HomeMAUI.MainPage">
-
-    <ScrollView>
-        <VerticalStackLayout
-            Padding="30,0"
-            Spacing="25">
-            <Image
-                Source="dotnet_bot.png"
-                HeightRequest="185"
-                Aspect="AspectFit"
-                SemanticProperties.Description="dot net bot in a hovercraft number nine" />
-
-            <Label
-                Text="Hello, World!"
-                Style="{StaticResource Headline}"
-                SemanticProperties.HeadingLevel="Level1" />
-
-            <Label
-                Text="Welcome to &#10;.NET Multi-platform App UI"
-                Style="{StaticResource SubHeadline}"
-                SemanticProperties.HeadingLevel="Level2"
-                SemanticProperties.Description="Welcome to dot net Multi platform App U I" />
-
-            <Button
-                x:Name="CounterBtn"
-                Text="Click me" 
-                SemanticProperties.Hint="Counts the number of times you click"
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Fill" />
-        </VerticalStackLayout>
-    </ScrollView>
-
+    <CollectionView ItemsSource="{Binding Devices}" SelectionMode="Single" SelectionChanged="OnDeviceSelected">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:Device">
+                <StackLayout Padding="10">
+                    <Label Text="{Binding Name}" FontSize="18"/>
+                </StackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/HomeMAUI/MainPage.xaml.cs
+++ b/HomeMAUI/MainPage.xaml.cs
@@ -1,23 +1,26 @@
-﻿namespace HomeMAUI;
+using System.Linq;
+using HomeMAUI.Models;
+using HomeMAUI.ViewModels;
+
+namespace HomeMAUI;
 
 public partial class MainPage : ContentPage
 {
-	int count = 0;
+    public MainPage()
+    {
+        InitializeComponent();
+        BindingContext = new MainViewModel();
+    }
 
-	public MainPage()
-	{
-		InitializeComponent();
-	}
-
-	private void OnCounterClicked(object? sender, EventArgs e)
-	{
-		count++;
-
-		if (count == 1)
-			CounterBtn.Text = $"Clicked {count} time";
-		else
-			CounterBtn.Text = $"Clicked {count} times";
-
-		SemanticScreenReader.Announce(CounterBtn.Text);
-	}
+    async void OnDeviceSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (e.CurrentSelection.FirstOrDefault() is Device device)
+        {
+            await Shell.Current.GoToAsync(nameof(ConnectPage), new Dictionary<string, object>
+            {
+                { "device", device }
+            });
+            ((CollectionView)sender!).SelectedItem = null;
+        }
+    }
 }

--- a/HomeMAUI/Models/Device.cs
+++ b/HomeMAUI/Models/Device.cs
@@ -1,0 +1,8 @@
+namespace HomeMAUI.Models;
+
+public class Device
+{
+    public string Name { get; set; } = string.Empty;
+    public int Rssi { get; set; }
+    public string BleAddress { get; set; } = string.Empty;
+}

--- a/HomeMAUI/ViewModels/MainViewModel.cs
+++ b/HomeMAUI/ViewModels/MainViewModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.ObjectModel;
+using HomeMAUI.Models;
+
+namespace HomeMAUI.ViewModels;
+
+public class MainViewModel
+{
+    public ObservableCollection<Device> Devices { get; } = new()
+    {
+        new Device { Name = "Device 1", Rssi = -40, BleAddress = "AA:BB:CC:DD:EE:01" },
+        new Device { Name = "Device 2", Rssi = -55, BleAddress = "AA:BB:CC:DD:EE:02" },
+        new Device { Name = "Device 3", Rssi = -60, BleAddress = "AA:BB:CC:DD:EE:03" }
+    };
+}


### PR DESCRIPTION
## Summary
- list devices on the home screen
- show connect screen then dashboard with device details
- remove connect page from stack so back returns to home

## Testing
- `dotnet build` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7bb00c788320871474295b8ba4c0