### PR TITLE
Improve device listing and selection

### DIFF
--- a/HomeMAUI/HomePage.xaml
+++ b/HomeMAUI/HomePage.xaml
@@ -3,18 +3,25 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:HomeMAUI"
              xmlns:vm="clr-namespace:HomeMAUI.ViewModels"
+             xmlns:model="clr-namespace:HomeMAUI.Models"
              x:Class="HomeMAUI.HomePage"
              x:DataType="vm:HomeViewModel">
     <local:BasePage.BindingContext>
         <vm:HomeViewModel />
     </local:BasePage.BindingContext>
-    <CollectionView ItemsSource="{Binding Devices}"
+    <CollectionView x:Name="DevicesCollectionView"
+                    ItemsSource="{Binding Devices}"
                     SelectionMode="Single"
-                    SelectedItem="{Binding SelectedDevice}">
+                    SelectionChanged="OnDeviceSelected">
         <CollectionView.ItemTemplate>
-            <DataTemplate>
+            <DataTemplate x:DataType="model:BleDevice">
                 <Frame Padding="10" Margin="10" BorderColor="LightGray">
-                    <Label Text="{Binding Name}" />
+                    <Grid ColumnDefinitions="*,Auto">
+                        <Label Text="{Binding Name}" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Rssi}"
+                               HorizontalOptions="End" />
+                    </Grid>
                 </Frame>
             </DataTemplate>
         </CollectionView.ItemTemplate>

--- a/HomeMAUI/HomePage.xaml.cs
+++ b/HomeMAUI/HomePage.xaml.cs
@@ -1,3 +1,8 @@
+using System.Linq;
+using HomeMAUI.Models;
+using HomeMAUI.ViewModels;
+using Microsoft.Maui.Controls;
+
 namespace HomeMAUI;
 
 public partial class HomePage : BasePage
@@ -5,5 +10,18 @@ public partial class HomePage : BasePage
     public HomePage()
     {
         InitializeComponent();
+    }
+
+    void OnDeviceSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (e.CurrentSelection.FirstOrDefault() is BleDevice device && BindingContext is HomeViewModel vm)
+        {
+            vm.SelectDeviceCommand.Execute(device);
+        }
+
+        if (sender is CollectionView collectionView)
+        {
+            collectionView.SelectedItem = null;
+        }
     }
 }

--- a/HomeMAUI/ViewModels/HomeViewModel.cs
+++ b/HomeMAUI/ViewModels/HomeViewModel.cs
@@ -15,9 +15,6 @@ public partial class HomeViewModel : BaseViewModel
 
     public ObservableCollection<BleDevice> Devices { get; } = new();
 
-    [ObservableProperty]
-    BleDevice? selectedDevice;
-
     public override Task InitializeAsync()
     {
         var rand = new Random();
@@ -33,18 +30,9 @@ public partial class HomeViewModel : BaseViewModel
         return Task.CompletedTask;
     }
 
-    partial void OnSelectedDeviceChanged(BleDevice? value)
-    {
-        if (value != null)
-        {
-            SelectDeviceCommand.Execute(value);
-        }
-    }
-
     [RelayCommand]
     async Task SelectDevice(BleDevice device)
     {
         await GetService<INavigationService>().GoToAsync(nameof(ConnectViewModel), device);
-        SelectedDevice = null;
     }
 }


### PR DESCRIPTION
## Summary
- Remove unused SelectedDevice property and binding
- Display device name and RSSI in home page collection cells
- Handle device selection in code-behind

## Testing
- `dotnet build HomeMAUI/HomeMAUI.csproj` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68adca81fc888320a94ad08c16e24540